### PR TITLE
Update KCL and connector, and pull in latest changes from upstream

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,18 +32,19 @@ repositories {
     mavenCentral()
 }
 
-ext.awsSdkVersion = '1.9.34'
+ext.awsSdkVersion = '1.10.15'
 
 configurations {
     compile.exclude group: 'commons-logging'
 }
 
 dependencies {
-    compile ('com.amazonaws:amazon-kinesis-connectors:1.1.1') {
+    compile ('com.amazonaws:amazon-kinesis-connectors:1.2.0') {
         // Exclude dependency on all of the SDK
         exclude group: 'com.amazonaws'
     }
-    compile ('com.amazonaws:amazon-kinesis-client:1.2.1') {
+    // connector tested with 1.4
+    compile ('com.amazonaws:amazon-kinesis-client:1.4.0') {
         // Exclude dependency on all of the SDK
         exclude group: 'com.amazonaws'
     }

--- a/src/main/java/com/scopely/infrastructure/kinesis/InjectableS3Emitter.java
+++ b/src/main/java/com/scopely/infrastructure/kinesis/InjectableS3Emitter.java
@@ -4,6 +4,7 @@ import com.amazonaws.services.kinesis.connectors.KinesisConnectorConfiguration;
 import com.amazonaws.services.kinesis.connectors.UnmodifiableBuffer;
 import com.amazonaws.services.kinesis.connectors.interfaces.IEmitter;
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -64,7 +65,9 @@ public class InjectableS3Emitter implements IEmitter<byte[]> {
         try {
             ByteArrayInputStream object = new ByteArrayInputStream(baos.toByteArray());
             LOGGER.debug("Starting upload of file " + s3URI + " to Amazon S3 containing " + records.size() + " records.");
-            s3.putObject(s3Bucket, s3FileName, object, null);
+            ObjectMetadata meta = new ObjectMetadata();
+            meta.setContentLength(baos.size());
+            s3.putObject(s3Bucket, s3FileName, object, meta);
             LOGGER.info("Successfully emitted " + buffer.getRecords().size() + " records to Amazon S3 in " + s3URI);
             return Collections.emptyList();
         } catch (Exception e) {

--- a/src/test/java/com/scopely/infrastructure/kinesis/KinesisRecorderTest.java
+++ b/src/test/java/com/scopely/infrastructure/kinesis/KinesisRecorderTest.java
@@ -32,8 +32,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static org.fest.assertions.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.isNull;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
@@ -162,7 +162,7 @@ public class KinesisRecorderTest {
 
         ArgumentCaptor<ByteArrayInputStream> baisCaptor = ArgumentCaptor.forClass(ByteArrayInputStream.class);
 
-        verify(surveilledS3).putObject(anyString(), anyString(), baisCaptor.capture(), isNull(ObjectMetadata.class));
+        verify(surveilledS3).putObject(anyString(), anyString(), baisCaptor.capture(), any(ObjectMetadata.class));
 
         assertThat(baisCaptor.getValue()).isNotNull();
         baisCaptor.getValue().reset();


### PR DESCRIPTION
This does not use KCL 1.6.0, since that version is not compatible with the Kinesis Connector

This update brings the latency metrics now reported by Kinesis and the KCL