### PR TITLE
Use Rx / More efficient listing of objects

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ sourceCompatibility = 1.8
 
 group = 'com.scopely'
 mainClassName = 'com.scopely.infrastructure.kinesis.KinesisVcr'
+applicationDefaultJvmArgs=['-XX:+UseG1GC', '-Xmx6G', '-Xms6G']
 
 repositories {
     jcenter()

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,6 @@ sourceCompatibility = 1.8
 
 group = 'com.scopely'
 mainClassName = 'com.scopely.infrastructure.kinesis.KinesisVcr'
-applicationDefaultJvmArgs=['-XX:+UseG1GC', '-Xmx6G', '-Xms6G']
 
 repositories {
     jcenter()

--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ apply plugin: 'application'
 apply plugin: 'com.github.johnrengelman.shadow'
 apply plugin: 'os-package-base'
 apply plugin: 'release'
+apply plugin: 'maven'
 
 sourceCompatibility = 1.8
 
@@ -39,6 +40,7 @@ configurations {
 }
 
 dependencies {
+    compile 'io.reactivex:rxjava:1.0.14'
     compile ('com.amazonaws:amazon-kinesis-connectors:1.2.0') {
         // Exclude dependency on all of the SDK
         exclude group: 'com.amazonaws'

--- a/src/main/java/com/scopely/infrastructure/kinesis/ExponentialBackoffRunner.java
+++ b/src/main/java/com/scopely/infrastructure/kinesis/ExponentialBackoffRunner.java
@@ -1,0 +1,52 @@
+package com.scopely.infrastructure.kinesis;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Optional;
+import java.util.function.Predicate;
+
+/**
+ * Made (with love?) by Erik Price
+ */
+public class ExponentialBackoffRunner {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ExponentialBackoffRunner.class);
+
+    @FunctionalInterface
+    public interface CheckedExceptionTask<U> {
+        U run() throws Throwable;
+    }
+    /**
+     * Repeatedly run a task until it succeeds, or the specified timeout period
+     * has been hit, whichever comes first.
+     *
+     * @param task Task to be run with retry
+     * @param retryPredicate Predicate that evaluates true on throwables that we should retry
+     * @param timeoutMillis Maximum time to wait for success
+     */
+    public static <T> Optional<T> run(CheckedExceptionTask<T> task, Predicate<Throwable> retryPredicate, long timeoutMillis) throws Throwable {
+        final long endTime = System.currentTimeMillis() + timeoutMillis;
+        for (int n = 0; System.currentTimeMillis() < endTime; ++n) {
+            try {
+                return Optional.of(task.run());
+            } catch (Throwable e) {
+                if (!retryPredicate.test(e)) {
+                    // If we get some unknown kind of error, just rethrow
+                    throw e;
+                }
+                long sleepTime = 1000 * (1 << n);
+                // Make sure we don't oversleep too much
+                if (System.currentTimeMillis() + sleepTime >= endTime) {
+                    sleepTime = Math.max(endTime - System.currentTimeMillis(), 1);
+                }
+                try {
+                    Thread.sleep(sleepTime);
+                } catch (InterruptedException ex) {
+                    LOGGER.info("Thread.sleep() interrupted", ex);
+                }
+            }
+        }
+        LOGGER.warn("No success after retry timeout expired");
+        return Optional.empty();
+    }
+}

--- a/src/main/java/com/scopely/infrastructure/kinesis/KinesisVcr.java
+++ b/src/main/java/com/scopely/infrastructure/kinesis/KinesisVcr.java
@@ -6,6 +6,7 @@ import com.amazonaws.services.kinesis.AmazonKinesis;
 import com.amazonaws.services.kinesis.AmazonKinesisClient;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3Client;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,7 +39,12 @@ public class KinesisVcr {
             }
 
             KinesisPlayer player = new KinesisPlayer(vcrConfiguration, s3, kinesis);
-            player.play(start, end);
+            int count = player.play(start, end)
+                              .count()
+                              .toBlocking()
+                              .first();
+
+            LOGGER.info("Wrote {} records to output Kinesis stream {}", count, vcrConfiguration.targetStream);
         } else {
             KinesisRecorder recorder = new KinesisRecorder(vcrConfiguration, s3, credentialsProvider);
             recorder.run();

--- a/src/main/java/com/scopely/infrastructure/kinesis/KinesisVcr.java
+++ b/src/main/java/com/scopely/infrastructure/kinesis/KinesisVcr.java
@@ -45,6 +45,7 @@ public class KinesisVcr {
                               .first();
 
             LOGGER.info("Wrote {} records to output Kinesis stream {}", count, vcrConfiguration.targetStream);
+            player.stop();
         } else {
             KinesisRecorder recorder = new KinesisRecorder(vcrConfiguration, s3, credentialsProvider);
             recorder.run();

--- a/src/main/java/com/scopely/infrastructure/kinesis/OperatorBufferKinesisBatch.java
+++ b/src/main/java/com/scopely/infrastructure/kinesis/OperatorBufferKinesisBatch.java
@@ -1,0 +1,118 @@
+package com.scopely.infrastructure.kinesis;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import rx.Observable;
+import rx.Producer;
+import rx.Subscriber;
+
+/**
+ * A version of {@link rx.internal.operators.OperatorBufferWithSize} which buffers {@link ByteBuffer}s
+ * that don't exceeded the configured count and size.
+ */
+public class OperatorBufferKinesisBatch implements Observable.Operator<List<ByteBuffer>, ByteBuffer> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(OperatorBufferKinesisBatch.class);
+
+    final int maxCount;
+    final int maxSize;
+
+    /**
+     * @param maxCount the number of elements a buffer should have before being emitted
+     * @param maxSize  max size in bytes of each list of ByteBuffers.
+     */
+    public OperatorBufferKinesisBatch(int maxCount, int maxSize) {
+        if (maxCount <= 0) {
+            throw new IllegalArgumentException("maxCount must be greater than 0");
+        }
+        if (maxSize <= 0) {
+            throw new IllegalArgumentException("maxSize must be greater than 0");
+        }
+        this.maxCount = maxCount;
+        this.maxSize = maxSize;
+    }
+
+    @Override
+    public Subscriber<? super ByteBuffer> call(final Subscriber<? super List<ByteBuffer>> child) {
+        return new Subscriber<ByteBuffer>(child) {
+            List<ByteBuffer> buffer;
+            AtomicInteger totalBufferSize;
+
+            @Override
+            public void setProducer(final Producer producer) {
+                child.setProducer(new Producer() {
+
+                    private volatile boolean infinite = false;
+
+                    @Override
+                    public void request(long n) {
+                        if (infinite) {
+                            return;
+                        }
+                        if (n >= Long.MAX_VALUE / maxCount) {
+                            // n == Long.MAX_VALUE or n * maxCount >= Long.MAX_VALUE
+                            infinite = true;
+                            producer.request(Long.MAX_VALUE);
+                        } else {
+                            producer.request(n * maxCount);
+                        }
+                    }
+                });
+            }
+
+            @Override
+            public void onNext(ByteBuffer bytes) {
+                if (buffer == null) {
+                    buffer = new ArrayList<>(maxCount);
+                    totalBufferSize = new AtomicInteger();
+                }
+
+                int currentBufferSize = bytes.limit();
+                boolean reachedSizeLimit = totalBufferSize.get() + currentBufferSize > maxSize;
+
+                if (reachedSizeLimit && buffer.isEmpty()) {
+                    LOGGER.warn("Dropping single ByteBuffer which was too big for the configured max size.");
+                    return;
+                }
+
+                if (!reachedSizeLimit) {
+                    totalBufferSize.addAndGet(currentBufferSize);
+                    buffer.add(bytes);
+                }
+
+                if (reachedSizeLimit || buffer.size() == maxCount) {
+                    List<ByteBuffer> oldBuffer = buffer;
+                    buffer = null;
+                    child.onNext(oldBuffer);
+                }
+            }
+
+            @Override
+            public void onError(Throwable e) {
+                buffer = null;
+                totalBufferSize = null;
+                child.onError(e);
+            }
+
+            @Override
+            public void onCompleted() {
+                List<ByteBuffer> oldBuffer = buffer;
+                buffer = null;
+                if (oldBuffer != null) {
+                    try {
+                        child.onNext(oldBuffer);
+                    } catch (Throwable t) {
+                        onError(t);
+                        return;
+                    }
+                }
+                child.onCompleted();
+            }
+        };
+    }
+}

--- a/src/test/java/com/scopely/infrastructure/kinesis/KinesisRecorderTest.java
+++ b/src/test/java/com/scopely/infrastructure/kinesis/KinesisRecorderTest.java
@@ -10,7 +10,6 @@ import com.amazonaws.services.kinesis.AmazonKinesisClient;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.ObjectMetadata;
-import com.amazonaws.services.s3.model.S3ObjectSummary;
 import com.amazonaws.util.IOUtils;
 
 import org.fest.assertions.core.Condition;
@@ -24,6 +23,7 @@ import org.slf4j.LoggerFactory;
 import java.io.ByteArrayInputStream;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
@@ -31,8 +31,6 @@ import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-
-import rx.Observable;
 
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
@@ -125,18 +123,20 @@ public class KinesisRecorderTest {
 
         Thread.sleep(TimeUnit.SECONDS.toMillis(45));
 
-        List<S3ObjectSummary> objectSummaries = s3.listObjects(bucketName).getObjectSummaries();
-        assertThat(objectSummaries).isNotEmpty();
-
         KinesisPlayer player = new KinesisPlayer(configuration, s3, kinesis);
-
-        assertThat(Observable.from(objectSummaries).flatMap(player::objectToPayloads).toList().toBlocking().first())
-                .are(new Condition<byte[]>() {
-                    @Override
-                    public boolean matches(byte[] value) {
-                        return Arrays.equals(value, new byte[40_000]);
-                    }
-                });
+        List<byte[]> result = player
+                .playableObjects(LocalDate.now(), LocalDate.now())
+                .flatMap(player::objectToPayloads)
+                .toList()
+                .toBlocking()
+                .first();
+        assertThat(result).isNotEmpty();
+        assertThat(result).are(new Condition<byte[]>() {
+            @Override
+            public boolean matches(byte[] value) {
+                return Arrays.equals(value, new byte[40_000]);
+            }
+        });
 
         executorService.shutdown();
         executorService.awaitTermination(10, TimeUnit.SECONDS);


### PR DESCRIPTION
- The VCR player is now using Rx to read data from S3 and replay it
- I also changed the way objects are listed from S3, so that it only looks for objects under the date range.
**This actually changes the previous behavior**. Before this change, providing just _start_ date would replay all data older or equal to that date. With this changeset, providing just _start_ date would replay data for just that date.
- Data is send to kinesis from a thread pool whose parallelism level depends on the number of shards in the target stream.