### PR TITLE
Replay speed

### DIFF
--- a/src/main/java/com/scopely/infrastructure/kinesis/KinesisPlayer.java
+++ b/src/main/java/com/scopely/infrastructure/kinesis/KinesisPlayer.java
@@ -219,7 +219,8 @@ public class KinesisPlayer {
         })
                 .subscribeOn(Schedulers.io())
                 .flatMap(x -> x)
-                .filter(x -> dateFilter.test(x.getLastModified()));
+                .filter(x -> dateFilter.test(x.getLastModified()))
+                .onBackpressureBuffer();
     }
 
     /**

--- a/src/main/java/com/scopely/infrastructure/kinesis/KinesisVcr.java
+++ b/src/main/java/com/scopely/infrastructure/kinesis/KinesisVcr.java
@@ -59,6 +59,7 @@ public class KinesisVcr {
                     .first();
 
             LOGGER.info("Wrote {} records to output Kinesis stream {}", count, vcrConfiguration.targetStream);
+            System.exit(0);
         } else {
             KinesisRecorder recorder = new KinesisRecorder(vcrConfiguration, s3, credentialsProvider);
             recorder.run();

--- a/src/test/java/com/scopely/infrastructure/kinesis/KinesisRecorderTest.java
+++ b/src/test/java/com/scopely/infrastructure/kinesis/KinesisRecorderTest.java
@@ -25,6 +25,7 @@ import java.io.ByteArrayInputStream;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
@@ -131,7 +132,7 @@ public class KinesisRecorderTest {
         KinesisPlayer player = new KinesisPlayer(configuration, s3, kinesis);
 
         Observable<byte[]> bytesObservable = player
-                .playableObjects(LocalDateTime.now(), LocalDateTime.now().plusDays(1))
+                .playableObjects(LocalDateTime.now().truncatedTo(ChronoUnit.DAYS), LocalDateTime.now().plusDays(1))
                 .flatMap(player::objectToPayloads);
 
         TestSubscriber<byte[]> testSubscriber = new TestSubscriber<>();


### PR DESCRIPTION
 This introduces some changes to the subscription and emission semantics to speed up replay.

Stability looks good, and performance is many times real-time:

```bash
$ time VCR_TARGET_STREAM_NAME=data-recovery VCR_BUCKET_NAME=kinesis-backups VCR_SOURCE_STREAM_NAME=source-stream ./build/install/kinesis-vcr/bin/kinesis-vcr play 2015-05-21T10:00:00 2015-05-21T10:10:00
[main] INFO com.scopely.infrastructure.kinesis.KinesisVcr - Wrote 452186 records to output Kinesis stream data-recovery

real	0m30.040s
user	0m28.702s
sys	0m4.708s
```

With a ten-minute input window, this is 20 times real-time.
