### PR TITLE
Move to G1 GC, use 6GB heap, and use later KCL so errors kill the worker

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ sourceCompatibility = 1.8
 
 group = 'com.scopely'
 mainClassName = 'com.scopely.infrastructure.kinesis.KinesisVcr'
+applicationDefaultJvmArgs = ['-XX:+UseG1GC', '-XX:+UseStringDeduplication', '-Xmx6g', -Xms6g']
 
 repositories {
     jcenter()
@@ -45,11 +46,7 @@ dependencies {
         // Exclude dependency on all of the SDK
         exclude group: 'com.amazonaws'
     }
-    // connector tested with 1.4
-    compile ('com.amazonaws:amazon-kinesis-client:1.4.0') {
-        // Exclude dependency on all of the SDK
-        exclude group: 'com.amazonaws'
-    }
+    compile ('com.amazonaws:amazon-kinesis-client:1.6.1')
     compile "com.amazonaws:aws-java-sdk-s3:${project.ext.awsSdkVersion}"
     compile "com.amazonaws:aws-java-sdk-kinesis:${project.ext.awsSdkVersion}"
     compile "com.amazonaws:aws-java-sdk-dynamodb:${project.ext.awsSdkVersion}"

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ sourceCompatibility = 1.8
 
 group = 'com.scopely'
 mainClassName = 'com.scopely.infrastructure.kinesis.KinesisVcr'
-applicationDefaultJvmArgs = ['-XX:+UseG1GC', '-XX:+UseStringDeduplication', '-Xmx6g', -Xms6g']
+applicationDefaultJvmArgs = ['-XX:+UseG1GC', '-XX:+UseStringDeduplication', '-Xmx6g', '-Xms6g']
 
 repositories {
     jcenter()


### PR DESCRIPTION
The VCR can become unstable when under memory pressure-- this PR gives it more memory and ups the KCL version to benefit from the fix in 1.5.0 to not swallow fatal errors emitted by the ShardConsumers; this would let the VCR get in a state where it is no longer processing data but is still holding the lease.