### PR TITLE
Use default-jre instead of oracle-java8-installer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ dependencies {
 ospackage {
     packageName project.name
 
-    requires('oracle-java8-installer')
+    requires('default-jre')
 
     into "/opt/scopely/${project.name}"
     from ("${project.buildDir}/scripts") {


### PR DESCRIPTION
The trigger for this change is deprecation of the webupd8 ppa for oracle-java8-installer, with the change we won't depend on any particular implementation.